### PR TITLE
fix slight bug. think this should be validator.sh

### DIFF
--- a/workspace/start-validator.sh
+++ b/workspace/start-validator.sh
@@ -2,4 +2,4 @@
 
 ./prepare-new-validator-keys.sh
 
-./start-validator.sh
+./validator.sh


### PR DESCRIPTION
this ends up in a loop trying to call start-validator.sh over and over again. I think this should be:
```
./validator.sh
```